### PR TITLE
Optimistic UI updates

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -34,7 +34,7 @@
     <div class="container">
       <div class="row">
         <div class="col" style="text-align: center">
-          <h1>Crafty.eth</h1>
+          <h1>Crafty<small style="font-size: large"> (alpha)</small></h1>
         </div>
       </div>
       <div class="row">

--- a/app/index.html
+++ b/app/index.html
@@ -40,7 +40,7 @@
       <div class="row">
         <div class="col-4">
           <div class="row">
-            <div class="col" data-toggle="tooltip" data-placement="left" title="The inventory is updated when new blocks are mined">
+            <div class="col" data-toggle="tooltip" data-placement="left" title="Pending transactions are updated when new blocks are mined">
               <h4><b>Inventory</b></h4>
               <div class="row">
                 <div class="col" id="basic-item-inv">

--- a/app/js/src/ethnet.js
+++ b/app/js/src/ethnet.js
@@ -27,6 +27,26 @@ function init() {
 }
 
 /*
+ * Returns true when the transaction has been confirmed.
+ */
+exports.isTxConfirmed = async (txHash) => {
+  const tx = await ethnet.web3.eth.getTransactionAsync(txHash);
+
+  // A transaction is considered confirmed once it's in a block that we have
+  // seen (blockNumber is null when the transaction is pending)
+  return ((tx.blockNumber !== null) && (tx.blockNumber <= ethnet.currentBlock.number));
+};
+
+/*
+ * Returns true when a transaction was successful. The transaction is assumed
+ * to be confirmed.
+ */
+exports.isTxSuccessful = async (txHash) => {
+  const receipt = await ethnet.web3.eth.getTransactionReceiptAsync(txHash);
+  return Number(receipt.status) !== 0;
+};
+
+/*
  * Creates a crafty contract object, used to interact with a deployed instance.
  * @returns the created contract, or undefined if one wasn't found.
  */

--- a/app/js/src/ethnet.js
+++ b/app/js/src/ethnet.js
@@ -112,11 +112,11 @@ exports.onNewBlock = async (handler) => {
 };
 
 /*
- * Returns a function that generates an URL from a transaction hash, linking to
- * information about that transaction.
+ * Returns an URL from a transaction hash, linking to information about that
+ * transaction.
  */
-exports.txUrlGen = () => {
-  return netInfo[ethnet.netId] ? netInfo[ethnet.netId].txUrlGen : () => '';
+exports.txUrl = (tx) => {
+  return netInfo[ethnet.netId] ? netInfo[ethnet.netId].txUrlGen(tx) : '';
 };
 
 /*

--- a/app/js/src/ethnet.js
+++ b/app/js/src/ethnet.js
@@ -125,7 +125,6 @@ exports.onNewBlock = async (handler) => {
 
     if (ethnet.currentBlock.number !== newBlock.number) {
       ethnet.currentBlock = newBlock;
-
       handler(ethnet.currentBlock);
     }
   }, 1000);

--- a/app/js/src/view.js
+++ b/app/js/src/view.js
@@ -50,8 +50,10 @@ exports.addItemList = (craftables, parent) => {
 };
 
 /*
- * Creates a set of buttons that trigger pendable transactions.
- * @param items An array of the craftables to be obtained in each transaction.
+ * Creates a set of buttons.
+ * @param items An array of the craftables to be crafted with each button.
+ * @param onclick A callback function to call with a craftable when its button
+ * is clicked.
  * @param parent The HTML object the list of buttons is going to be appended to.
  * An enableCraft function is added to the UI property of each craftable, which
  * receives a boolean value indicating if it can be crafted or not, and updates
@@ -59,7 +61,7 @@ exports.addItemList = (craftables, parent) => {
  * @returns An object mapping item names to a function that enables or disables
  * the associated button.
  */
-exports.addPendableTxButtons = (craftables, onclick, parent) => {
+exports.addCraftButtons = (craftables, onclick, parent) => {
   const listGroup = $('<div>').addClass('list-group align-items-center');
   craftables.forEach(craftable => {
     // The title of the button will reflect if transactions are pending
@@ -72,7 +74,6 @@ exports.addPendableTxButtons = (craftables, onclick, parent) => {
 
     button.click(() => {
       button.blur(); // To prevent the button from remaining 'active'
-
       onclick(craftable);
     });
 
@@ -171,7 +172,7 @@ function toastTokenAddressCopied(copied) {
   if (copied) {
     toastr['info']('Token copied to clipboard');
   } else {
-    toastr['warn']('Failed to copy token');
+    toastr['warning']('Failed to copy token');
   }
 }
 
@@ -187,6 +188,13 @@ exports.toastSuccessfulTx = (tx, url) => {
       window.open(url, '_blank');
     }
   }});
+};
+
+/*
+ * Generates a failed to send transaction toast.
+ */
+exports.toastFailedToSendTx = () => {
+  toastr['warning']('Failed to send a transaction');
 };
 
 /*

--- a/app/js/src/view.js
+++ b/app/js/src/view.js
@@ -40,7 +40,7 @@ exports.addItemList = (craftables, parent) => {
     const amountSpan = $('<span>');
     craftable.ui.updateAmount = newVal => {
       amountSpan.text(newVal);
-      amountSpan.fadeOut(500, () =>amountSpan.fadeIn(500));
+      amountSpan.fadeOut(300, () =>amountSpan.fadeIn(300));
     };
     li.append(amountSpan);
 
@@ -52,10 +52,6 @@ exports.addItemList = (craftables, parent) => {
 /*
  * Creates a set of buttons that trigger pendable transactions.
  * @param items An array of the craftables to be obtained in each transaction.
- * @param parametrizeAction The action to execute when a button is clicked,
- * parametrized with the item corresponding to said button.
- * @param urlFromTX a function that returns a transaction URL when called
- * with a transaction hash.
  * @param parent The HTML object the list of buttons is going to be appended to.
  * An enableCraft function is added to the UI property of each craftable, which
  * receives a boolean value indicating if it can be crafted or not, and updates
@@ -63,44 +59,21 @@ exports.addItemList = (craftables, parent) => {
  * @returns An object mapping item names to a function that enables or disables
  * the associated button.
  */
-exports.addPendableTxButtons = (craftables, parametrizeAction, urlFromTx, parent) => {
+exports.addPendableTxButtons = (craftables, onclick, parent) => {
   const listGroup = $('<div>').addClass('list-group align-items-center');
   craftables.forEach(craftable => {
     // The title of the button will reflect if transactions are pending
-    const button = $(`<button type="button" title="">Get ${craftable.name}</button>`);
+    const button = $(`<button type="button">Get ${craftable.name}</button>`);
     button.addClass('list-group-item').addClass('list-group-item-action d-flex justify-content-between align-items-center');
 
     craftable.ui.enableCraft = enabled => {
       button.prop('disabled', !enabled);
     };
 
-    // A badge will track the number of pending transactions
-    const badge = $('<span>').addClass('badge badge-secondary badge-pill');
-    button.append(badge);
-
-    let pendingTxs = 0;
-    button.click(async () => {
+    button.click(() => {
       button.blur(); // To prevent the button from remaining 'active'
 
-      pendingTxs += 1;
-      badge.text(pendingTxs);
-      button.attr('title', 'Pending TXs');
-
-      try {
-        // The action to execute is the result of parametrizing it with the craftable name
-        const result = await parametrizeAction(craftable.name);
-        toastSuccessfulTx(result.tx, urlFromTx(result.tx));
-
-      } catch (e) {
-        toastErrorTx();
-
-      } finally {
-        pendingTxs -= 1;
-        badge.text(pendingTxs > 0 ? pendingTxs : '');
-        if (pendingTxs === 0) {
-          button.attr('title', '');
-        }
-      }
+      onclick(craftable);
     });
 
     listGroup.append(button);
@@ -158,7 +131,6 @@ exports.setBlock = (block) => {
   }
 
   view.block = block;
-  $('#last-block').fadeOut(500, () => $('#last-block').fadeIn(500));
 };
 
 /*
@@ -209,20 +181,20 @@ function toastTokenAddressCopied(copied) {
  * @param url (optional) A link to where more information about the transaction
  * can be found.
  */
-function toastSuccessfulTx(tx, url) {
-  toastr['success'](tx, 'Broadcasted TX!', {onclick: () => {
+exports.toastSuccessfulTx = (tx, url) => {
+  toastr['success'](tx, 'Successful transaction!', {onclick: () => {
     if (url) {
       window.open(url, '_blank');
     }
   }});
-}
+};
 
 /*
  * Generates a failed transaction toast.
  */
-function toastErrorTx() {
-  toastr['error']('Failed to broadcast TX');
-}
+exports.toastErrorTx = () => {
+  toastr['error']('Transaction failed');
+};
 
 toastr.options = {
   'positionClass': 'toast-bottom-center',

--- a/app/js/src/view.js
+++ b/app/js/src/view.js
@@ -179,9 +179,9 @@ exports.hideModalError = () => {
  */
 function toastTokenAddressCopied(copied) {
   if (copied) {
-    toastr['info']('Token copied to clipboard');
+    toastr['info']('Token copied to clipboard', '' , {'positionClass': 'toast-bottom-center'});
   } else {
-    toastr['warning']('Failed to copy token');
+    toastr['warning']('Failed to copy token', '' , {'positionClass': 'toast-bottom-center'});
   }
 }
 
@@ -214,7 +214,7 @@ exports.toastErrorTx = () => {
 };
 
 toastr.options = {
-  'positionClass': 'toast-bottom-center',
+  'positionClass': 'toast-bottom-right',
   'preventDuplicates': false,
   'showDuration': '300',
   'hideDuration': '1000',

--- a/app/js/src/view.js
+++ b/app/js/src/view.js
@@ -19,7 +19,7 @@ exports.init = () => {
  * @param craftables An array of craftables.
  * @param parent The HTML object the list is going to be appended to.
  * An updateAmount function is added to the UI property of each craftable,
- * which receives a new craftable amount and updates the DOM.
+ * which receives a craftable's current and pending amounts and updates the DOM.
  */
 exports.addItemList = (craftables, parent) => {
   const list = $('<ul>').addClass('list-group').css({'background-color': 'transparent'});
@@ -37,12 +37,21 @@ exports.addItemList = (craftables, parent) => {
     labelSpan.text(` ${craftable.name}: `).addClass('first-letter');
     li.append(labelSpan);
 
-    const amountSpan = $('<span>');
-    craftable.ui.updateAmount = newVal => {
-      amountSpan.text(newVal);
-      amountSpan.fadeOut(300, () =>amountSpan.fadeIn(300));
+    const currentAmountSpan = $('<span>');
+    const pendingAmountBadge = $('<span>').addClass('badge badge-secondary badge-pill');
+
+    craftable.ui.updateAmount = (currentVal, pendingVal) => {
+      currentAmountSpan.text(`${currentVal} `); // Spacing for the badge
+
+      if (pendingVal > 0) {
+        pendingAmountBadge.fadeIn(600).text(`(+ ${pendingVal} being crafted)`);
+      } else {
+        pendingAmountBadge.fadeOut(600);
+      }
     };
-    li.append(amountSpan);
+
+    li.append(currentAmountSpan);
+    li.append(pendingAmountBadge);
 
     list.append(li);
   });


### PR DESCRIPTION
Included here:
* Once a craft transaction is sent (approved on the Ethereum Browser), its ingredients are subtracted immediately from the inventory (to prevent them from being used again), and the result is marked as 'being crafted' (to prevent it from being used before it's ready)
* Upon confirmation of pending transactions, a toast is shown, and pending items are marked as ready (and can then be used as ingredients)
* Transactions rejected via the Ethereum Browser now get a special error message

I felt that updating the inventory before the transaction is approved by the user might be confusing. However, not doing so allows for the same transaction to be queued multiple times: if a player can only craft one iron sword, and he attempts to craft three before approving the first transaction, he will be able to broadcast transactions that will fail. 

This is not ideal, but it takes active intent to break the UI from the user, and I feel the 'do something' -> 'sign transaction (and pay for it!)' -> 'results' flow makes more sense.

Closes #23